### PR TITLE
use theme secondary color for active selection controls

### DIFF
--- a/src/stylus/settings/_theme.styl
+++ b/src/stylus/settings/_theme.styl
@@ -51,7 +51,7 @@ $material-light := {
     focus: #EEEEEE
   },
   selection-controls: {
-    active: $teal.base,
+    active: $theme.secondary,
     thumb: {
       inactive: $grey.lighten-5,
       disabled: $grey.lighten-1


### PR DESCRIPTION
Theme definitions using fixed teal color for active selection control instead of theme specific color.

This PR sets the theme secondary color for active selection controls.